### PR TITLE
use browser defaults to parse urls

### DIFF
--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -56,6 +56,10 @@ async function processCurrentPage(): Promise<void> {
 
         // Get video id
         const videoId = new URL(window.location.href).searchParams.get("v");
+        if (!videoId) {
+            log("video id not found");
+            return;
+        }
         log("video id: " + videoId);
 
         // Wait for the bottom row to be available in the DOM

--- a/src/content/index.ts
+++ b/src/content/index.ts
@@ -55,7 +55,7 @@ async function processCurrentPage(): Promise<void> {
         log("video detected!");
 
         // Get video id
-        const videoId = window.location.href.split("v=")[1].split("&")[0];
+        const videoId = new URL(window.location.href).searchParams.get("v");
         log("video id: " + videoId);
 
         // Wait for the bottom row to be available in the DOM

--- a/src/content/utils/thumbnails.ts
+++ b/src/content/utils/thumbnails.ts
@@ -23,7 +23,7 @@ export async function handleThumbnails(): Promise<void> {
 
             const thumbnailLinkElement: HTMLAnchorElement | null = thumbnail.querySelector("#content ytd-rich-grid-media #dismissible #details #meta #title, #video-title-link, #dismissible ytd-thumbnail #thumbnail");
 
-            const videoId = thumbnailLinkElement ? thumbnailLinkElement.href?.split("v=")[1].split("&")[0] : null;
+            const videoId = thumbnailLinkElement ? new URL(thumbnailLinkElement.href).searchParams.get("v") : null;
 
             if (videoId === null || channelUrl === null) {
                 log("video id or channel not found");


### PR DESCRIPTION
hey, It's me again.
I don't want to bother you, and feel free to share your opinion on this, but I stumbled upon your videoId parsing approach.

While I guess it should work fine for most cases, there are some edge cases that could be easily prevented by using the browser defaults.

e.g. opening a link with an anchor to the comments section
`https://www.youtube.com/watch?v=4-YXdvUs1_M#comments`
will parse as `4-YXdvUs1_M#comments` with your approach.

I guess we can assume browser support für browsers without `URL` support is off the table.